### PR TITLE
Helpers portion: Add auto generator to add partial and module sass files to main.scss

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "brei-assemble-helpers",
+  "version": "1.0.1",
+  "description": "custom-handlebar-helpers",
+  "main": "helpers.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified. MAKE THEM!\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BarkleyREI/brei-assemble-helpers"
+  },
+  "author": "Joseph Dillon",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/BarkleyREI/brei-assemble-helpers/issues"
+  },
+  "homepage": "https://github.com/BarkleyREI/brei-assemble-helpers"
+}

--- a/updateScss.js
+++ b/updateScss.js
@@ -1,0 +1,42 @@
+var fs = require('fs');
+var path = require('path');
+var collection = [
+	{
+		'name': 'partials',
+		'dir': './app/assemble/partials'
+	},
+	{
+		'name': 'modules',
+		'dir': './app/assemble/modules'
+	}
+];
+
+var createScss = function(e) {
+	var finallScss = '';
+	console.log('Updating Assemble.io sass...');
+
+	fs.readdir(e.dir, function(err, list) {
+	  if (err) { throw err; }
+
+	  var finalPath = './app/sass/' + e.name + '/_assemble-' + e.name +'.scss';
+
+	  list.forEach(function(e) {
+	  	var data = '@import "';
+
+	    if (path.extname(e) === '.hbs') {
+	      data = data + path.basename(e, '.hbs');
+	      finallScss = finallScss + data + '";\n';
+	    }
+	  })
+
+	  fs.writeFile(finalPath, finallScss, function(err) {
+	  	if (err) { throw err; }
+
+	  	console.log('Done! ' + e.name + ' updated!');
+	  });
+	});
+};
+
+collection.forEach(function(data) {
+	createScss(data);
+});


### PR DESCRIPTION
I'm personally pretty proud of this one.

This is the helper part to https://github.com/BarkleyREI/generator-brei-app/issues/31
This node script will run whenever new `.hbs` file is added. It bases it's auto magic off of the `.hbs` files and not the `.scss` files A) to avoid weird issues where its trying to read itself, and B) because it creates the `_assemble-modules/partials.scss` files. If you want to add a new style than you still need to add it to the `main.scss` itself.

I also added a package.json to track versions.

This will not break anything. Woot.
